### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,9 @@ from tkinter import filedialog, Text, scrolledtext, messagebox
 from tkinter import ttk
 import os
 
+# Store the base directory
+base_dir = os.path.dirname(os.path.abspath(__file__))
+
 # Initialise Tkinter
 root = tk.Tk()
 root.title("Smart Contract Builder")
@@ -39,9 +42,12 @@ def insert_file(event=None):
     # Get selected file
     file = listbox.get(listbox.curselection())
 
+    # Form the full path to the file
+    full_path = os.path.join(base_dir, file)
+
     # Read the file
     try:
-        with open(file, "r") as f:
+        with open(full_path, "r") as f:
             content = f.read()
 
         # Insert content at cursor position


### PR DESCRIPTION
- patch addressing new issue: this error is occurring because the application is trying to open the file using a relative path (in this case, 'ERC20.sol'), but the current working directory isn't the directory containing the file.
- fixed this issue by storing the base directory and using it to form the full path when opening the file. 
- in this updated code, os.path.dirname(os.path.abspath(__file__)) gets the directory of the current Python script (__file__ is a built-in variable that contains the path of the script), and os.path.join(base_dir, file) forms the full path to the file.